### PR TITLE
Fixed for Unity 2022

### DIFF
--- a/Editor/MarkerEditor.cs
+++ b/Editor/MarkerEditor.cs
@@ -1,4 +1,4 @@
-// Marker by ksivl / VRLabs 3.0 Assets https://github.com/VRLabs/VRChat-Avatars-3.0
+// Marker by ksivl / VRLabs 3.0 Assets https://github.com/VRLabs/VRChat-Avatars-3.0 / 2022 fix by Betty
 #if UNITY_EDITOR
 using System;
 using System.IO;


### PR DESCRIPTION
VRChat updated to Unity 2022, and Unity 2022 no longer supports Boo. Simply removed Boo from the MarkerEditor.cs script.